### PR TITLE
Add support for in line logic expression for filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.93"
 calm_io = "0.1.1"
 clap = { version = "4.5.1", features = ["derive"] }
 flate2 = "1.0.28"
+pom = "3.4.0"
 rayon = "1.9.0"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"

--- a/README.md
+++ b/README.md
@@ -39,10 +39,13 @@ vcf_parser -i test/test.vcf --fields CSQ,Pangolin --fields-join Feature,pangolin
 An example of `filter.yml` can be found in the `test/` folder. You can replace `eq` with `=` or `==`, `le` with `<=` or `≤`, etc.
 Equivalently, you can now pass a logic expression as a string to the `-f` option. For example:
 ```bash
-vcf_parser -i test/test.vcf -f "(info.AF <= 0.01 AND info.CSQ.IMPACT in (HIGH,MODERATE)) AND (info.CADD_PHRED >=20 OR info.Pangolin.pangolin_max_score >= 0.5 or info.Pangolin.pangolin_max_score <= -0.5)" --fields CSQ,Pangolin --fields-join Feature,pangolin_transcript
+vcf_parser -i test/test.vcf -f "(info.AF <= 0.01 AND info.CSQ.IMPACT in (HIGH, MODERATE)) AND (info.CADD_PHRED >=20 OR info.Pangolin.pangolin_max_score >= 0.5 or info.Pangolin.pangolin_max_score <= -0.5)" --fields CSQ,Pangolin --fields-join Feature,pangolin_transcript
 ```
 **NOTE**: As in the current implementation, "AND" and "OR" have the same precedence. Please use parentheses to make the logic expression unambiguous.
-
+If you have a list of genes to filter stored in a file, you can do it so:
+```bash
+vcf_parser -i test/test.vcf -f "info.CSQ.Gene in (`cat genes.txt`)" --fields CSQ,Pangolin --fields-join Feature,pangolin_transcript
+```
 ### Options
 ```
 -h #help 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features
 * Accept arbitrarily sophisticated filters defined in a yaml file.
 * Multithreaded
 * Output in JSON or TSV format
+* Support logic expression for filters (experimental)
 
 Installation
 ------------
@@ -36,12 +37,17 @@ vcf_parser -i test/test.vcf --fields CSQ,Pangolin --fields-join Feature,pangolin
 ```
 
 An example of `filter.yml` can be found in the `test/` folder. You can replace `eq` with `=` or `==`, `le` with `<=` or `≤`, etc.
+Equivalently, you can now pass a logic expression as a string to the `-f` option. For example:
+```bash
+vcf_parser -i test/test.vcf -f "(info.AF <= 0.01 AND info.CSQ.IMPACT in (HIGH,MODERATE)) AND (info.CADD_PHRED >=20 OR info.Pangolin.pangolin_max_score >= 0.5 or info.Pangolin.pangolin_max_score <= -0.5)" --fields CSQ,Pangolin --fields-join Feature,pangolin_transcript
+```
+**NOTE**: As in the current implementation, "AND" and "OR" have the same precedence. Please use parentheses to make the logic expression unambiguous.
 
 ### Options
 ```
 -h #help 
 -i <input.vcf[.gz]>  
--f <filter.yaml>
+-f <filter.yaml or expression>
 -t <thread number>
 -l # to list columns and exit
 -c <columns to output>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,19 +390,11 @@ mod tests {
 
         let exprs = [
             (r#"foo = bar AND baz > 10"#, r#"{"AND":[{"name":"foo","op":"=","value":"bar"},{"name":"baz","op":">","value":10.0}]}"#),
-            (r#"foo = bar OR baz > 10 AND baz < 5"#, r#"{"OR":[{"name":"foo","op":"=","value":"bar"},{"name":"baz","op":">","value":10.0},{"name":"baz","op":"<","value":5.0}]}"#),
-            //(r#"foo = bar AND baz > 10 AND baz < 5"#, r#"{"AND":[{"name":"foo","op":"=","value":"bar"},{"name":"baz","op":">","value":10.0},{"name":"baz","op":"<","value":5.0}]}"#),
+            (r#"(foo == bar or baz > 10) AND baz <= 5"#, r#"{"AND":[{"OR":[{"name":"foo","op":"==","value":"bar"},{"name":"baz","op":">","value":10.0}]},{"name":"baz","op":"<=","value":5.0}]}"#),
         ];
         for (expr, expected) in exprs.iter() {
             let result = parser::parse_logic_expr(expr)?;
             assert_eq!(result, serde_json::from_str::<serde_json::Value>(expected)?);
-        }
-        let input = r#"foo = bar AND baz > 10"#;
-
-        let result = parser::parse_logic_expr(input);
-        match result {
-            Ok(res) => println!("{}", res),
-            Err(e) => println!("Logic Error: {:?}", e),
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod vcfparser;
 pub mod variant;
 pub mod utils;
 pub mod error;
+pub mod parser;
 
 #[derive(Parser)]
 #[command(version = "0.2.4", about = "Read a (normalised) .vcf[.gz] and output tsv/json. CSQ-aware.", long_about = None)]
@@ -375,6 +376,18 @@ mod tests {
             serde_json::from_str(r#"{"key1": "value3", "key11": null, "key2": "value4"}"#).unwrap(),
         ];
         assert_eq!(joined_table, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_logic() -> Result<(), Box<dyn Error>> {
+        let input = r#"foo = "bar" AND baz > 10"#;
+
+        let result = parser::parse_logic_expr(input);
+        match result {
+            Ok(res) => println!("{}", res),
+            Err(e) => println!("Logic Error: {:?}", e),
+        }
         Ok(())
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,7 +116,7 @@ fn and_or<'a>() -> Parser<'a, u8, String> {
 
 fn property_val<'a>() -> Parser<'a, u8, Value> {
     space()
-        * ((lparen() * list(value(), sym(b',') * space()) - rparen())
+        * ((lparen() * list(value(), sym(b',').opt() * space()) - rparen())
             .map(|g| json!(g))
             | value())
         - space()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,151 @@
+use pom::parser::*;
+use pom::char_class::*;
+use std::str::{self, FromStr};
+use serde_json::{Value, json};
+
+#[derive(Debug)]
+#[derive(serde::Serialize)]
+pub enum PropertyVal {
+    SimpleValue(Value),
+    Group(Vec<Value>),
+}
+
+// Define the parser for whitespace
+fn space<'a>() -> Parser<'a, u8, ()> {
+    one_of(b" \t\r\n").repeat(0..).discard()
+}
+
+// Define the parser for identifiers
+fn ident<'a>() -> Parser<'a, u8, String> {
+    one_of(b"._abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789").repeat(1..).convert(String::from_utf8)
+}
+
+// Define the parser for operators
+fn operator<'a>() -> Parser<'a, u8, String> {
+    (seq(b"=") 
+    | seq(b"<") 
+    | seq(b">") 
+    | seq(b"is") 
+    | seq(b"==") 
+    | seq(b"<=") 
+    | seq(b">=")
+    | seq(b"!=")
+    | seq(b"eq")
+    | seq(b"ne")
+    | seq(b"gt")
+    | seq(b"ge")
+    | seq(b"lt")
+    | seq(b"le")
+).convert(|arg0: &[u8]| String::from_utf8(arg0.to_vec()))
+}
+
+fn lparen<'a>() -> Parser<'a, u8, ()> {
+    seq(b"(").discard()
+}
+
+fn rparen<'a>() -> Parser<'a, u8, ()> {
+    seq(b")").discard()
+}
+
+fn real_number<'a>() -> Parser<'a, u8, f64> {
+    let integer = one_of(b"123456789") - one_of(b"0123456789").repeat(0..) | sym(b'0');
+    let frac = sym(b'.') + one_of(b"0123456789").repeat(1..);
+    let exp = one_of(b"eE") + one_of(b"+-").opt() + one_of(b"0123456789").repeat(1..);
+    let number = sym(b'-').opt() + integer + frac.opt() + exp.opt();
+    number
+        .collect()
+        .convert(str::from_utf8)
+        .convert(|s| f64::from_str(&s))
+}
+
+fn integer<'a>() -> Parser<'a, u8, u8> {
+    one_of(b"123456789") - one_of(b"0123456789").repeat(0..) | sym(b'0')
+}
+
+fn str<'a>() -> Parser<'a, u8, String> {
+    (sym(b'"') * none_of(b"\"").repeat(0..) - sym(b'"')).convert(String::from_utf8)
+}
+
+fn bool<'a>() -> Parser<'a, u8, Value> {
+    ((seq(b"t") | seq(b"T"))
+        + (seq(b"r") | seq(b"R"))
+        + (seq(b"u") | seq(b"U"))
+        + (seq(b"e") | seq(b"E")))
+    .map(|_| Value::Bool(true))
+        | ((seq(b"f") | seq(b"F"))
+            + (seq(b"a") | seq(b"A"))
+            + (seq(b"l") | seq(b"L"))
+            + (seq(b"s") | seq(b"S"))
+            + (seq(b"e") | seq(b"E")))
+        .map(|_| Value::Bool(true))
+}
+
+fn none<'a>() -> Parser<'a, u8, u8> {
+    ((seq(b"n") | seq(b"N"))
+        + (seq(b"o") | seq(b"O"))
+        + (seq(b"n") | seq(b"N"))
+        + (seq(b"e") | seq(b"E")))
+    .map(|_| 0)
+}
+
+fn value<'a>() -> Parser<'a, u8, Value> {
+    space()
+        * (real_number().map(|f| Value::from(f))
+            | integer().map(|i| Value::Number(i.into()))
+            | str().map(|s| Value::String(s))
+            | bool()
+            | none().map(|_| Value::Null)
+            | ident().map(|s| Value::String(s))
+        )
+        - space()
+}
+
+fn and<'a>() -> Parser<'a, u8, u8> {
+    ((seq(b"a") | seq(b"A")) + (seq(b"n") | seq(b"N")) + (seq(b"d") | seq(b"D"))).map(|_| 0)
+}
+
+fn or<'a>() -> Parser<'a, u8, u8> {
+    ((seq(b"o") | seq(b"O")) + (seq(b"r") | seq(b"R"))).map(|_| 0)
+}
+
+fn and_or<'a>() -> Parser<'a, u8, String> {
+    and().map(|_| "AND".into()) | or().map(|_| "OR".into())
+}
+
+// Define the parser for values (numbers, strings, or null)
+fn _value<'a>() -> Parser<'a, u8, Value> {
+    is_a(digit).repeat(1..).convert(String::from_utf8).convert(|arg0: std::string::String| f64::from_str(&arg0)).map(Value::from)
+        | sym(b'"') * none_of(b"\"").repeat(1..).convert(String::from_utf8).map(Value::from) - sym(b'"')
+        | seq(b"null").map(|_| Value::Null)
+}
+
+fn property_val<'a>() -> Parser<'a, u8, Value> {
+    space()
+        * ((lparen() * list(value(), sym(b',') * space()) - rparen())
+            .map(|g| json!(g))
+            | value())
+        - space()
+}
+
+fn boolean_condition<'a>() -> Parser<'a, u8, Value> {
+    space()
+        * ((property_val() + operator() + property_val())
+            .map(|((lval, op), rval)| json!({"name": lval, "op": op, "value": rval}))
+            | (lparen() * call(boolean_expression) - rparen()).map(|boolean_expression| {
+                json!(boolean_expression)
+            }))
+        - space()
+}
+
+fn boolean_expression<'a>() -> Parser<'a, u8, Value> {
+    (boolean_condition() + (and_or()) + call(boolean_expression)).map(
+        |((boolean_condition, and_or_initial), boolean_expression)| json!({
+            and_or_initial: [boolean_condition, boolean_expression]
+        })
+    ) | boolean_condition()
+}
+
+// Define the main parser function
+pub fn parse_logic_expr<'a>(input: &str) -> Result<Value, pom::Error> {
+    (space() * boolean_expression() - end()).parse(input.as_bytes())
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,20 +22,23 @@ fn ident<'a>() -> Parser<'a, u8, String> {
 
 // Define the parser for operators
 fn operator<'a>() -> Parser<'a, u8, String> {
-    (seq(b"=") 
-    | seq(b"<") 
-    | seq(b">") 
+    (seq(b"==") 
     | seq(b"is") 
-    | seq(b"==") 
+    | seq(b"=") 
     | seq(b"<=") 
     | seq(b">=")
     | seq(b"!=")
+    | seq(b"<") 
+    | seq(b">")
     | seq(b"eq")
     | seq(b"ne")
     | seq(b"gt")
     | seq(b"ge")
     | seq(b"lt")
     | seq(b"le")
+    | seq(b"in")
+    | seq("≥".as_bytes())
+    | seq("≤".as_bytes())
 ).convert(|arg0: &[u8]| String::from_utf8(arg0.to_vec()))
 }
 
@@ -138,7 +141,7 @@ fn boolean_condition<'a>() -> Parser<'a, u8, Value> {
 }
 
 fn boolean_expression<'a>() -> Parser<'a, u8, Value> {
-    (boolean_condition() + (and_or()) + call(boolean_expression)).map(
+    (boolean_condition() + and_or() + call(boolean_expression)).map(
         |((boolean_condition, and_or_initial), boolean_expression)| json!({
             and_or_initial: [boolean_condition, boolean_expression]
         })
@@ -147,5 +150,6 @@ fn boolean_expression<'a>() -> Parser<'a, u8, Value> {
 
 // Define the main parser function
 pub fn parse_logic_expr<'a>(input: &str) -> Result<Value, pom::Error> {
+    //(space() * boolean_expression() - end()).parse(input.as_bytes())
     (space() * boolean_expression() - end()).parse(input.as_bytes())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,4 @@
 use pom::parser::*;
-use pom::char_class::*;
 use std::str::{self, FromStr};
 use serde_json::{Value, json};
 
@@ -113,13 +112,6 @@ fn or<'a>() -> Parser<'a, u8, u8> {
 
 fn and_or<'a>() -> Parser<'a, u8, String> {
     and().map(|_| "AND".into()) | or().map(|_| "OR".into())
-}
-
-// Define the parser for values (numbers, strings, or null)
-fn _value<'a>() -> Parser<'a, u8, Value> {
-    is_a(digit).repeat(1..).convert(String::from_utf8).convert(|arg0: std::string::String| f64::from_str(&arg0)).map(Value::from)
-        | sym(b'"') * none_of(b"\"").repeat(1..).convert(String::from_utf8).map(Value::from) - sym(b'"')
-        | seq(b"null").map(|_| Value::Null)
 }
 
 fn property_val<'a>() -> Parser<'a, u8, Value> {


### PR DESCRIPTION
Implement logic expression for filters.
For example, one can now pass filters like:
```
vcf_parser -i test/test.vcf -f "info.AF <= 0.01 and info.CSQ.IMPACT in (HIGH, MODERATE)"
```